### PR TITLE
Update apv.md

### DIFF
--- a/docs/apv.md
+++ b/docs/apv.md
@@ -159,6 +159,10 @@ De overtreding beschreven in lid 1 staat bekend als “spam”
 ### Artikel 14 - Nederlandse Taal
 
 1. Er wordt van spelers verwacht de Nederlandse taal te beheersen. Indien iemand de Nederlandse taal niet beheerst is deze persoon niet welkom op de server.
+2. Andere talen dan het Nederlands en het Engels mogen niet gebruikt worden op een provocerende of beledigende manier gedurende de roleplay. 
+3. Tijdens een staffgesprek en tijdens een gesprek met een medewerker van een overheidsdienst (Politie, KMar, ambulance of ANWB) dient de persoon te allen tijde Nederlands te spreken indien de medewerker dit wenst. 
+4. Bij een overtreding van de regel in lid 2 en 3 wordt de overtreder bestraft met een bestraffing van de 1e categorie.
+5. Bij herhaalde overtreding zal er een straf van de 2e categorie volgen.
 
 ### Artikel 15 - Reporting
 


### PR DESCRIPTION
- Aanpassing van Artikel 14 van de APV omwille van een aantal recente incidenten waarbij er provocerende en beledigende opmerkingen werden geuit tegen spelers in moderne vreemde talen. Het is vanaf heden verboden om een vreemde taal (behalve het Engels) te gebruiken om beledigende opmerkingen te maken en het is verplicht om Nederlands te spreken in een roleplay met bijvoorbeeld een politieagent indien hij dit wenst.