### PR TITLE
Inbeslagname bij overlijden tijdens een misdrijf.

### DIFF
--- a/docs/wetboek.md
+++ b/docs/wetboek.md
@@ -66,6 +66,7 @@
    * Zal deze, wanneer, met inachtneming van de vorige regel, het voertuig tevens uit het water moest worden gehaald, uitgekocht kunnen worden voor 30% van de cataloguswaarde;
    * Is er een vastgesteld maximum voor bovenstaande uitkoopbedragen van ten hoogste €200,000
    * Zal deze kosteloos worden teruggegeven (na eventueel onderzoek) indien de eigenaar geen strafbaar feit ten laste is gelegd, of kan gelegd worden, welke in directe zin gekoppeld is aan de reden van inbeslagname.
+   * Wanneer het voertuig bewijsbaar onderdeel was van het misdrijf en de eigenaar daarvan overleden is, dan zal het voertuig uitgekocht kunnen worden voor 20% van de cataloguswaarde.
 
 ### A7 - Openstaande boetes
 


### PR DESCRIPTION
Dit omdat de RP van de verdachte stopt. Echter de RP van de politie loopt bijna altijd wel gewoon door.