### PR TITLE
Toevoeging artikel omtrent jobhoppen

### DIFF
--- a/docs/apv.md
+++ b/docs/apv.md
@@ -362,9 +362,15 @@ Het overtreden van het feit genoemd in lid 1 zal resulteren in een straf van de 
 1. Het is verboden voor de bestuurder om van uit een voertuig een vuurwapen af te vuren.
 2. Bij overtreding van het feit beschreven in lid 1 wordt een straf van de 1e categorie uitgedeeld.
 
+### Artikel 46 - Jobhoppen
+
+1. Gangleden dienen minimaal een maand te wachten nadat zij de groep verlaten voordat zij aangenomen mogen worden bij een overheidsbaan of bij een andere gang. 
+2. (Ex-)medewerkers van een overheidsbaan dienen minimaal een week te wachten nadat ze ontslag hebben genomen/ontslagen zijn voordat zij aangenomen mogen worden bij een andere overheidsbaan. 
+3. Bij overtreding van de feiten beschreven in lid 1 en/of lid 2 wordt een straf van de 1e categorie uitgedeeld en zal de desbetreffende persoon worden ontslagen. 
+
 ## Tijdelijke bepalingen
 
-### Artikel 46 - Uitbreken uit de gevangenis
+### Artikel 47 - Uitbreken uit de gevangenis
 
 1. Het is verboden om tussen 01:00 en 08:00 uit de gevangenis te breken.
 2. Bij overtreding van het feit beschreven in lid 1 wordt een straf van de 2e categorie uitgedeeld.


### PR DESCRIPTION
- Het is vanaf heden verplicht voor gangleden om minstens een maand te wachten voordat zij aangenomen kunnen worden bij een overheidsbaan of een andere gang. 
- Hetzelfde geldt voor overheidsmedewerkers, maar dan voor een duur van 7 dagen.