### PR TITLE
Aanpassing impersonatie overheidsmedewerker

### DIFF
--- a/docs/apv.md
+++ b/docs/apv.md
@@ -212,8 +212,10 @@ De overtreding beschreven in lid 1 staat bekend als “spam”
 
 ### Artikel 22 - Impersonatie overheidsmedewerker
 
-1. Het is verboden om jezelf te verkleden als overheidsmedewerker.
-2. Bij overtreding van lid 1 zal er een straf uitgedeeld worden volgens de 2e categorie.
+1. Het is verboden om jezelf te verkleden als overheidsmedewerker en impliciet of expliciet aan te geven dat je een overheidsmedewerker bent. Dit is ter beoordeling aan een stafflid.
+2. Het is toegestaan om kogelwerende vesten te dragen, echter is het verboden als er termen als "Politie" opstaan, redelijkerwijs gebruikt worden door de Nederlandse politie/koninklijke marechaussee of verwijzen naar de Politie/KMar. 
+3. Waar is verwezen naar de Politie/KMar in dit artikel kan ook een officiële vertakking van deze overheidsdiensten (zoals de recherche of de dienst speciale interventies) of een andere officiële overheidsdienst worden ingevuld. 
+4. Bij overtreding van lid 1 en/of lid 2 zal er een straf uitgedeeld worden volgens de 2e categorie.
 
 ### Artikel 23 - SafeZone FailRP
 


### PR DESCRIPTION
- Er is een verduidelijk toegevoegd aan artikel 22 omtrent het voordoen als overheidsmedewerker. Het is vanaf heden verboden om impliciet en/of expliciet aan te geven dat je een overheidsmedewerker bent. Met expliciet bedoelen we dat je letterlijk zegt dat je bijvoorbeeld bij de Politie werkt. Met impliciet bedoelen we dat je niet daadwerkelijk zegt dat je van een overheidsinstantie bent, maar dat je dit wel laat zien door bepaalde gedragingen, uitingen en/of uitspraken. 
- Daarnaast is het dragen van kogelwerende vesten verduidelijkt, omdat hierover soms discussie ontstond. Het is toegestaan om kogelwerende vesten te dragen, maar dit is niet toegestaan als:
a) Er termen als "Politie", "KMar" of dergelijke opstaan;
b) Deze redelijkerwijs wordt gebruikt door de politie, KMar of andere overheidsinstantie;
c) Deze redelijkerwijs verwijst naar een overheidsinstantie.