### PR TITLE
Recht op bijstand Advocaat tijdens huiszoeking (artikel 99a sv)

### DIFF
--- a/docs/wetboek.md
+++ b/docs/wetboek.md
@@ -754,6 +754,7 @@
    * wanneer ontlastende informatie wordt verzwegen, en/of bewijsmateriaal wordt vernietigd;
    * het tappen van een met geheimhoudingsplicht bezwaarde professional, zoals arts, notaris, geestelijke, apotheker, advocaat;
    * het voeren van een meinedig proces-verbaal zijnde tegenstrijdigheid met andere processen-verbaal, camerabeelden, geluidsopnamen;
+   * inbreuk op het recht van een verdachte op aanwezigheid van een advocaat tijdens een huiszoeking (en andere rechten van een verdachte), ook wel een verdedigingsrecht genoemd, bestaat er voor de (hulp-)Officier van justitie en de rechter een mogelijkheid om de inbreuk te herstellen.
 
 ### Artikel VII-3 Strafvermindering (44a.2 SR)
 
@@ -879,8 +880,6 @@
 ### Artikel VIII-12 Recht op bijstand Advocaat tijdens huiszoeking (artikel 99a sv)
 
 1. De verdachte is bevoegd zich tijdens het doorzoeken van plaatsen door zijn advocaat te doen bijstaan, zonder dat de doorzoeking daardoor mag worden opgehouden.
-2. Bij een inbreuk op het recht van een verdachte op aanwezigheid van een advocaat tijdens een huiszoeking (en andere rechten van een verdachte), ook wel een verdedigingsrecht genoemd, bestaat er voor de rechter een mogelijkheid om de inbreuk te herstellen.
-3. De rechter kan, afhankelijk van de omstandigheden van het geval en de ernst van de inbreuk op het verdedigingsrecht zoals beschreven in lid 2, overgaan tot: strafvermindering, bewijsuitsluiting of niet-ontvankelijkverklaring van het openbaar ministerie in de vervolging.
 
 ## Titel IX – Schadevergoeding
 

--- a/docs/wetboek.md
+++ b/docs/wetboek.md
@@ -876,6 +876,12 @@
 | Tweede Veroordeling  | 40 maanden | | €15.000  |
 | Meerdere Veroordelingen  | 60 maanden |  | €20.000  |
 
+### Artikel VIII-12 Recht op bijstand Advocaat tijdens huiszoeking (artikel 99a sv)
+
+1. De verdachte is bevoegd zich tijdens het doorzoeken van plaatsen door zijn advocaat te doen bijstaan, zonder dat de doorzoeking daardoor mag worden opgehouden.
+2. Bij een inbreuk op het recht van een verdachte op aanwezigheid van een advocaat tijdens een huiszoeking (en andere rechten van een verdachte), ook wel een verdedigingsrecht genoemd, bestaat er voor de rechter een mogelijkheid om de inbreuk te herstellen.
+3. De rechter kan, afhankelijk van de omstandigheden van het geval en de ernst van de inbreuk op het verdedigingsrecht zoals beschreven in lid 2, overgaan tot: strafvermindering, bewijsuitsluiting of niet-ontvankelijkverklaring van het openbaar ministerie in de vervolging.
+
 ## Titel IX – Schadevergoeding
 
 ### Artikel IX-1 (Im)materiële schadevergoeding voor onterechte inverzekeringstelling of voorlopige hechtenis (artikel 533 sv)


### PR DESCRIPTION
Het Wetboek van Strafvordering geeft aan een verdachte het recht om zich tijdens een huiszoeking te doen bijstaan door een advocaat, hetgeen betekent dat de advocaat tijdens een huiszoeking aanwezig mag zijn. Een advocaat kan op deze manier controle uitoefenen op de manier waarop de politie een huiszoeking verricht en de belangen van een cliënt te behartigen.