### PR TITLE
Toevoeging strafbepaling

### DIFF
--- a/docs/wetboek.md
+++ b/docs/wetboek.md
@@ -36,8 +36,9 @@
 2. Een opgelegde straf kan een combinatie zijn van de bovenstaande strafvormen.
 3. Een opgelegde straf is nooit hoger dan de vastgestelde waarden.
 4. Een straf kan wel verhoogd worden door het stapelen van overtredingen.
-5. Een straf kan ook verlaagd worden door verzachtende omstandigheden.
-6. Een straf kan geheel of gedeeltelijk kwijtgescholden of uitgesloten worden op basis van uitsluitingsgronden of bewijsbaar foutieve uitschrijving van de straf.
+5. Indien er sprake is van meerdere slachtoffers van een geweldsdelict, dan wordt er voor elk extra slachtoffer 25% van de oorspronkelijke straf bij de uiteindelijke straf toegevoegd. Bij 2 slachtoffers zal er dus sprake zijn van een strafverhoging van 25% van de normale strafmaat, en zo verder. 
+6. Een straf kan ook verlaagd worden door verzachtende omstandigheden.
+7. Een straf kan geheel of gedeeltelijk kwijtgescholden of uitgesloten worden op basis van uitsluitingsgronden of bewijsbaar foutieve uitschrijving van de straf.
 
 ### A4 - Strafblad
 

--- a/docs/wetboek.md
+++ b/docs/wetboek.md
@@ -36,7 +36,7 @@
 2. Een opgelegde straf kan een combinatie zijn van de bovenstaande strafvormen.
 3. Een opgelegde straf is nooit hoger dan de vastgestelde waarden.
 4. Een straf kan wel verhoogd worden door het stapelen van overtredingen.
-5. Indien er sprake is van meerdere slachtoffers van een geweldsdelict, dan wordt er voor elk extra slachtoffer 25% van de oorspronkelijke straf bij de uiteindelijke straf toegevoegd. Bij 2 slachtoffers zal er dus sprake zijn van een strafverhoging van 25% van de normale strafmaat, en zo verder. 
+5. Indien er sprake is van meerdere slachtoffers van een geweldsdelict, dan wordt er voor elk extra slachtoffer 25% van de oorspronkelijke straf bij de uiteindelijke straf toegevoegd. Bij 2 slachtoffers zal er dus sprake zijn van een strafverhoging van 25% van de normale strafmaat, en zo verder.
 6. Een straf kan ook verlaagd worden door verzachtende omstandigheden.
 7. Een straf kan geheel of gedeeltelijk kwijtgescholden of uitgesloten worden op basis van uitsluitingsgronden of bewijsbaar foutieve uitschrijving van de straf.
 


### PR DESCRIPTION
Als er meerdere slachtoffers zijn van een geweldsdelict, dan geldt er per extra slachtoffer een verhoging van de normale straf van 25%. Dit werd al toegepast, echter stond dit nog nergens vermeld. 

Rekenvoorbeeld: 
Er zijn 4 personen vermoord bij één bankoverval, dit is de eerste veroordeling voor de verdachte. Dan geldt er 100*1,75=175 maanden. Er zijn immers 3 EXTRA verdachten met elk 25% bovenop de strafmaat.