### PR TITLE
Verduidelijking crimineel gedrag tegen ambulancemedewerkers

### DIFF
--- a/docs/apv.md
+++ b/docs/apv.md
@@ -288,7 +288,7 @@ De overtreding beschreven in lid 1 staat bekend als “spam”
 
 ### Artikel 32 - Crimineel gedrag jegens ambulancemedewerkers en andere overheidsmedewerkers
 
-1. Het is ten strengste verboden om een ambulancemedewerker te ontvoeren, te gijzelen of negatief te bejegenen. Onder negatief bejegenen valt onder andere het beledigen van ambulancemedewerkers en het niet meewerken met de roleplay van een ambulancier.
+1. Het is ten strengste verboden om een ambulancemedewerker te ontvoeren, te gijzelen, te beledigen of niet mee te werken met de roleplay van een ambulancier.
 2. Het is niet toegestaan een melding te maken naar een overheids instantie met de intentie om degene die hierop reageert te vermoorden en/of te ontvoeren.
 3. Er moeten ten allen tijden vijf overheidsmedewerkers binnen een baan beschikbaar blijven nadat er één ontvoert is, dus als er 6 agenten aanwezig zijn mag er 1 ontvoert worden, als er 5 aanwezig zijn mag er geen ontvoert worden.
 4. Indien de regel beschreven in lid 1 overtreden wordt zal dit bestraft worden met een straf volgens de 5e categorie. Bij herhaalde overtreding volgt er ten hoogste een straf volgens de 6e categorie.

--- a/docs/apv.md
+++ b/docs/apv.md
@@ -288,7 +288,7 @@ De overtreding beschreven in lid 1 staat bekend als “spam”
 
 ### Artikel 32 - Crimineel gedrag jegens ambulancemedewerkers en andere overheidsmedewerkers
 
-1. Het is ten strengste verboden om een ambulancemedewerker te ontvoeren.
+1. Het is ten strengste verboden om een ambulancemedewerker te ontvoeren, te gijzelen of negatief te bejegenen. Onder negatief bejegenen valt onder andere het beledigen van ambulancemedewerkers en het niet meewerken met de roleplay van een ambulancier.
 2. Het is niet toegestaan een melding te maken naar een overheids instantie met de intentie om degene die hierop reageert te vermoorden en/of te ontvoeren.
 3. Er moeten ten allen tijden vijf overheidsmedewerkers binnen een baan beschikbaar blijven nadat er één ontvoert is, dus als er 6 agenten aanwezig zijn mag er 1 ontvoert worden, als er 5 aanwezig zijn mag er geen ontvoert worden.
 4. Indien de regel beschreven in lid 1 overtreden wordt zal dit bestraft worden met een straf volgens de 5e categorie. Bij herhaalde overtreding volgt er ten hoogste een straf volgens de 6e categorie.


### PR DESCRIPTION
- Vanaf heden staat het duidelijker in de APV dat ambulancemedewerkers niet ontvoerd en/of gegijzeld mogen worden. Daarnaast is het niet toegestaan om ambulanciers uit te schelden of niet mee te werken met hun roleplay. Dit werd al toegepast, maar nu staat dit duidelijk en volledig in de APV.