### PR TITLE
Correctie gevangenisstraf Artikel III-6

### DIFF
--- a/docs/wetboek.md
+++ b/docs/wetboek.md
@@ -403,7 +403,7 @@
 |   | *Celstraf*  | *Taakstraf*  | *boete*  | *rijontzegging* |
 |---|---|---|---|---|
 |  **Eerste Veroordeling** | 9 maanden |  | € 15000,-  |   |
-| **Tweede Veroordeling**  | 113 maanden  |  | € 16000,-  |   |
+| **Tweede Veroordeling**  | 13 maanden  |  | € 16000,-  |   |
 | **Meerdere Veroordelingen**  | 22 maanden  |  | € 18000,-  |   |
 
 ### Artikel III-7 Rijden onder invloed (8 WVW)


### PR DESCRIPTION
- Aangepast dat je voor Artikel III-6 Verlaten plaats van verkeersongeval (7 WVW) niet meer 113 maanden de cel in moet, maar 13. 