### PR TITLE
Use different mkdocs builder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,13 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.x
-      - run: pip install mkdocs-material
-      # - run: pip install mkdocs-git-authors-plugin
-      - run: pip install mkdocs-git-revision-date-localized-plugin
-      - run: mkdocs gh-deploy --force
+      - name: Deploy docs
+        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
 
       - name: Discord Commits      
         uses: Sniddl/discord-commits@v1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs-git-revision-date-localized-plugin
+mkdocs-material


### PR DESCRIPTION
Lijkt iets schoner zo me dunkt

Gebruikt een requirements.txt in plaats van hardcoded pip install in de actions. Heb t builden en deployen getest op eigen fork en werkt.