### PR TITLE
Toevoeging A11 - Medeplichtigheid en medeplegen

### DIFF
--- a/docs/wetboek.md
+++ b/docs/wetboek.md
@@ -126,8 +126,8 @@
 2. Er is sprake van medeplichtigheid als de verdachte behulpzaam is geweest bij het plegen van het strafbare feit van een ander persoon. Bij medeplichtigheid is de rol van de medeplichtige duidelijk kleiner dan de rol van de hoofdverdachte.
 3. Bij medeplichtigheid aan een strafbaar feit wordt de straf met 1/3 verminderd.
 4. Als daders van een strafbaar feit worden gestraft:
-    4. zij die het feit plegen, doen plegen of medeplegen;
-    4. zij die door giften, beloften, misbruik van gezag, geweld, bedreiging, of misleiding of door het verschaffen van gelegenheid, middelen of inlichtingen het feit opzettelijk uitlokken.
+   4. zij die het feit plegen, doen plegen of medeplegen;
+   4. zij die door giften, beloften, misbruik van gezag, geweld, bedreiging, of misleiding of door het verschaffen van gelegenheid, middelen of inlichtingen het feit opzettelijk uitlokken.
 5. Er is sprake van medeplegen indien twee of meer personen gezamenlijk een strafbaar feit plegen, waarbij er sprake is van een bewuste en nauwe samenwerking. Het draait hierbij voornamelijk om een samenwerking.
 6. Daders en medeplichtigen van een strafbaar feit worden gestraft volgens de strafbepaling van het desbetreffende artikel.
 7. Indien er onduidelijkheid is over medeplegen of medeplichtigheid tijdens een strafzaak dan kan een Hulpofficier van Justitie, Officier van Justitie of in uiterste gevallen een rechter hierover een eindoordeel vellen.

--- a/docs/wetboek.md
+++ b/docs/wetboek.md
@@ -85,8 +85,6 @@
     4. Niet voldoen aan (verkeers)aanwijzing van bevoegde en als zodanig kenbare opsporingsambtenaar;
     5. Snelheidsovertreding van meer dan 100% van de maximumsnelheid;
     6. Op de openbare weg rijden met een voertuig met daarop een WOK-status.
-4. Alle bovenstaande leden gelden ook voor heli's en vliegtuigen.
-5. Meerdere notities voor het vliegen zonder vliegbrevet zal resulteren in een inbeslag name van het voertuig.
 
 ### A8 - Openstaande boetes
 
@@ -120,6 +118,19 @@
     9. Détournement de pouvoir, waarbij de wet alleen mag toegepast worden waar deze voor bedoeld is;
     10. Ne bis in idem, waarbij iemand niet tweemaal veroordeeld mag worden voor hetzelfde feit;
     11. Het schutznorm-beginsel, waarbij er geen rechtsgevolg of sanctie wordt gekoppeld aan een vormfout als de verdachte niet zelf is getroffen in een (verdedigings)belang dat door het geschonden vormvoorschrift wordt beschermd.
+
+### A11 - Medeplichtigheid en medeplegen
+1. Als medeplichtigen van een strafbaar feit worden gestraft:
+    1. zij die opzettelijk behulpzaam zijn bij het plegen van het misdrijf;
+    1. zij die opzettelijk gelegenheid, middelen of inlichtingen verschaffen tot het plegen van het misdrijf.
+2. Er is sprake van medeplichtigheid als de verdachte behulpzaam is geweest bij het plegen van het strafbare feit van een ander persoon. Bij medeplichtigheid is de rol van de medeplichtige duidelijk kleiner dan de rol van de hoofdverdachte.
+2. Bij medeplichtigheid aan een strafbaar feit wordt de straf met 1/3 verminderd.
+3. Als daders van een strafbaar feit worden gestraft:
+    3. zij die het feit plegen, doen plegen of medeplegen;
+    3. zij die door giften, beloften, misbruik van gezag, geweld, bedreiging, of misleiding of door het verschaffen van gelegenheid, middelen of inlichtingen het feit opzettelijk uitlokken.
+4. Er is sprake van medeplegen indien twee of meer personen gezamenlijk een strafbaar feit plegen, waarbij er sprake is van een bewuste en nauwe samenwerking. Het draait hierbij voornamelijk om een samenwerking.
+5. Daders en medeplichtigen van een strafbaar feit worden gestraft volgens de strafbepaling van het desbetreffende artikel.
+6. Indien er onduidelijkheid is over medeplegen of medeplichtigheid tijdens een strafzaak dan kan een Hulpofficier van Justitie, Officier van Justitie of in uiterste gevallen een rechter hierover een eindoordeel vellen.
 
 ## Titel I - Vermogensdelicten
 

--- a/docs/wetboek.md
+++ b/docs/wetboek.md
@@ -122,12 +122,12 @@
 ### A11 - Medeplichtigheid en medeplegen
 1. Als medeplichtigen van een strafbaar feit worden gestraft:
     1. zij die opzettelijk behulpzaam zijn bij het plegen van het misdrijf;
-    1. zij die opzettelijk gelegenheid, middelen of inlichtingen verschaffen tot het plegen van het misdrijf.
+    2. zij die opzettelijk gelegenheid, middelen of inlichtingen verschaffen tot het plegen van het misdrijf.
 2. Er is sprake van medeplichtigheid als de verdachte behulpzaam is geweest bij het plegen van het strafbare feit van een ander persoon. Bij medeplichtigheid is de rol van de medeplichtige duidelijk kleiner dan de rol van de hoofdverdachte.
 3. Bij medeplichtigheid aan een strafbaar feit wordt de straf met 1/3 verminderd.
 4. Als daders van een strafbaar feit worden gestraft:
-   4. zij die het feit plegen, doen plegen of medeplegen;
-   4. zij die door giften, beloften, misbruik van gezag, geweld, bedreiging, of misleiding of door het verschaffen van gelegenheid, middelen of inlichtingen het feit opzettelijk uitlokken.
+   1. zij die het feit plegen, doen plegen of medeplegen;
+   2. zij die door giften, beloften, misbruik van gezag, geweld, bedreiging, of misleiding of door het verschaffen van gelegenheid, middelen of inlichtingen het feit opzettelijk uitlokken.
 5. Er is sprake van medeplegen indien twee of meer personen gezamenlijk een strafbaar feit plegen, waarbij er sprake is van een bewuste en nauwe samenwerking. Het draait hierbij voornamelijk om een samenwerking.
 6. Daders en medeplichtigen van een strafbaar feit worden gestraft volgens de strafbepaling van het desbetreffende artikel.
 7. Indien er onduidelijkheid is over medeplegen of medeplichtigheid tijdens een strafzaak dan kan een Hulpofficier van Justitie, Officier van Justitie of in uiterste gevallen een rechter hierover een eindoordeel vellen.

--- a/docs/wetboek.md
+++ b/docs/wetboek.md
@@ -85,6 +85,8 @@
     4. Niet voldoen aan (verkeers)aanwijzing van bevoegde en als zodanig kenbare opsporingsambtenaar;
     5. Snelheidsovertreding van meer dan 100% van de maximumsnelheid;
     6. Op de openbare weg rijden met een voertuig met daarop een WOK-status.
+4. Alle bovenstaande leden gelden ook voor heli's en vliegtuigen.
+5. Meerdere notities voor het vliegen zonder vliegbrevet zal resulteren in een inbeslag name van het voertuig.
 
 ### A8 - Openstaande boetes
 

--- a/docs/wetboek.md
+++ b/docs/wetboek.md
@@ -124,13 +124,13 @@
     1. zij die opzettelijk behulpzaam zijn bij het plegen van het misdrijf;
     1. zij die opzettelijk gelegenheid, middelen of inlichtingen verschaffen tot het plegen van het misdrijf.
 2. Er is sprake van medeplichtigheid als de verdachte behulpzaam is geweest bij het plegen van het strafbare feit van een ander persoon. Bij medeplichtigheid is de rol van de medeplichtige duidelijk kleiner dan de rol van de hoofdverdachte.
-2. Bij medeplichtigheid aan een strafbaar feit wordt de straf met 1/3 verminderd.
-3. Als daders van een strafbaar feit worden gestraft:
-    3. zij die het feit plegen, doen plegen of medeplegen;
-    3. zij die door giften, beloften, misbruik van gezag, geweld, bedreiging, of misleiding of door het verschaffen van gelegenheid, middelen of inlichtingen het feit opzettelijk uitlokken.
-4. Er is sprake van medeplegen indien twee of meer personen gezamenlijk een strafbaar feit plegen, waarbij er sprake is van een bewuste en nauwe samenwerking. Het draait hierbij voornamelijk om een samenwerking.
-5. Daders en medeplichtigen van een strafbaar feit worden gestraft volgens de strafbepaling van het desbetreffende artikel.
-6. Indien er onduidelijkheid is over medeplegen of medeplichtigheid tijdens een strafzaak dan kan een Hulpofficier van Justitie, Officier van Justitie of in uiterste gevallen een rechter hierover een eindoordeel vellen.
+3. Bij medeplichtigheid aan een strafbaar feit wordt de straf met 1/3 verminderd.
+4. Als daders van een strafbaar feit worden gestraft:
+    4. zij die het feit plegen, doen plegen of medeplegen;
+    4. zij die door giften, beloften, misbruik van gezag, geweld, bedreiging, of misleiding of door het verschaffen van gelegenheid, middelen of inlichtingen het feit opzettelijk uitlokken.
+5. Er is sprake van medeplegen indien twee of meer personen gezamenlijk een strafbaar feit plegen, waarbij er sprake is van een bewuste en nauwe samenwerking. Het draait hierbij voornamelijk om een samenwerking.
+6. Daders en medeplichtigen van een strafbaar feit worden gestraft volgens de strafbepaling van het desbetreffende artikel.
+7. Indien er onduidelijkheid is over medeplegen of medeplichtigheid tijdens een strafzaak dan kan een Hulpofficier van Justitie, Officier van Justitie of in uiterste gevallen een rechter hierover een eindoordeel vellen.
 
 ## Titel I - Vermogensdelicten
 


### PR DESCRIPTION
Er is een artikel toegevoegd aan de algemene bepalingen van het wetboek. Hiermee hopen we dat het verschil tussen medeplichtigheid, medeplegen en de rol van daders duidelijker wordt. Dit komt deels uit het Nederlandse wetboek van strafrecht. 
- In essentie is er bij medeplichtigheid sprake van een een minder belangrijke bijdrage van de verdachte ten opzichte van de hoofdverdachte. 
- Bij medeplegen is er sprake van een nauwe, sterk onmisbare samenwerking. 
Indien er nog onduidelijkheid heerst omtrent medeplegen en medeplichtigheid dan kan een (h)OvJ hierbij helpen.