### PR TITLE
Verduidelijking Artikel 45 - Discord

### DIFF
--- a/docs/apv.md
+++ b/docs/apv.md
@@ -438,9 +438,10 @@ Overtreding van lid 1 wordt bestraft met een straf in de 1e categorie.
 ### Artikel 45 - Discord
 
 1. Het is niet toegestaan om externe discords te gebruiken voor roleplay gerelateerde zaken.
-2. Wanneer je met meerdere mensen die op TedeaPolis spelen in een voice call zit is streamen niet toegestaan en moet je gedeafened en gemute zijn.
-3. Het overtreden van het feit genoemd in lid 1 of 2 zal resulteren in een straf van de 1e categorie.
-4. Het overtreden van het feit genoemd in lid 1 als eigenaar, moderator en/of stafflid van deze server zal resulteren in een straf van de 7e categorie.
+2. Wanneer je met meerdere mensen die op TedeaPolis spelen in een voicecall zit, is streamen niet toegestaan en moet je gedeafened en gemute zijn. Als één persoon in-game is en de rest niet en je besluit om alsnog in een call te zitten zonder dat je gedeafened/gemute bent, ben je dus ook in overtreding van deze regel.
+3. Het streamen van de main server in een discord server is nooit toegestaan, tenzij je expliciet toestemming hebt van een stafflid.
+4. Het overtreden van het feit genoemd in lid 1, 2 of 3 zal resulteren in een straf van de 1e categorie.
+5. Het overtreden van het feit genoemd in lid 1, 2 of 3 als eigenaar, moderator en/of stafflid van deze server zal resulteren in een straf van de 7e categorie.
 
 ### Artikel 46 - Zelfdoding
 


### PR DESCRIPTION
- Het artikel omtrent het gebruik van externe discords is verduidelijkt. Er staat nu duidelijker vermeld dat het NOOIT is toegestaan om de main server te streamen in een externe discord, tenzij je toestemming hebt van een stafflid. Daarnaast is er verduidelijkt wanneer het wel/niet is toegestaan om in call te zitten terwijl je in-game bent.