### PR TITLE
Lokaalvredebreuk (139 SR) - Aanpassing tekst

### DIFF
--- a/docs/wetboek.md
+++ b/docs/wetboek.md
@@ -949,7 +949,7 @@
 
 ### Artikel VIII-9 Lokaalvredebreuk (139 SR)
 
-1. Schuldig is een persoon die in een voor de openbare dienst bestemd lokaal, openbare ruimte of besloten erf dat bestemd is voor de openbare dienst, wederrechtelijk binnendringt, of, wederrechtelijk aldaar vertoevende, zich niet op de vordering van de bevoegde ambtenaar aanstonds verwijdert.
+1. Schuldig is een persoon die in een voor de openbare dienst bestemd lokaal, besloten erf of openbare ruimte, wederrechtelijk binnendringt, of, wederrechtelijk aldaar vertoevende, zich niet op de vordering van de bevoegde ambtenaar aanstonds verwijdert.
 2. Schuldig is een persoon die zich de toegang heeft verschaft door middel van braak of inklimming, van valse sleutels, van een valse order of een vals kostuum, of die zonder voorkennis van de bevoegde ambtenaar en anders dan ten gevolge van vergissing binnengekomen, aldaar wordt aangetroffen in de voor de nachtrust bestemde tijd, wordt geacht te zijn binnengedrongen.
 
 |  |Celstraf  | Taakstraf  | boete  |


### PR DESCRIPTION
Het woord 'bestemd' stond 2x in de zin. huidig voorstel maakt het wat duidelijker en meer leesbaar.