### PR TITLE
Aanpassing Artikel V-3 Steek- en slagwapens (27 WWM)

### DIFF
--- a/docs/wetboek.md
+++ b/docs/wetboek.md
@@ -757,7 +757,10 @@
 
 ### Artikel V-3 Steek- en slagwapens (27 WWM)
 
-1. Strafbaar is een persoon die een steek- of slagwapen voorhanden heeft, bij zich draagt, of opgeslagen heeft in huis of in de laadruimte van zijn of haar vervoersmiddel, waarvan redelijkerwijs kan worden aangenomen dat deze bestemd is om letsel toe te brengen.
+1. Strafbaar is een persoon die een steekwapen voorhanden heeft, bij zich draagt, of opgeslagen heeft in huis of in de laadruimte van zijn of haar vervoersmiddel.
+2. Strafbaar is een persoon die een slagwapen voorhanden heeft of bij zich draagt, waarvan redelijkerwijs kan worden aangenomen dat deze bestemd is om letsel toe te brengen.
+4. Er geldt een gedoogbeleid betreffende het bezit van steekwapens. Indien er geen strafbaar feit is gepleegd met het wapen, kan een persoon het wapen vrijwillig afgeven en in ruil daarvoor geen strafvervolging ondergaan. 
+5. In risicogebieden is het voorhanden hebben, bij je dragen, of opgeslagen hebben in huis of in de laadruimte van je vervoersmiddel van een steek- of slagwapen onder alle omstandigheden verboden. Het gedoogbeleid is dan niet van toepassing.
 
 |   | *Celstraf*  | *Taakstraf*  | *boete*  |
 |---|---|---|---|


### PR DESCRIPTION
Naar aanleiding van enorm veel onduidelijkheid is ervoor gekozen om een uitgebreide wijziging aan te brengen aan het artikel omtrent steek- en slagwapens. 

Vanaf heden zijn steekwapens in principe altijd verboden. Voorheen waren er heel veel verschillende manieren waarop dit artikel werd geïnterpreteerd. Vanaf nu is er een duidelijke richtlijn. Indien er een steekwapen wordt aangetroffen geldt er een gedoogbeleid op het moment dat er geen strafbaar feit mee is gepleegd. Als je je wapen vrijwilig afgeeft (en er is dus geen strafbaar feit mee gepleegd), zul je niet worden vervolgd en mag je je weg dus vervolgen. 

Slagwapens zijn enkel verboden als je ze direct bij je hebt (dus niet in je auto of iets in die richting) en je er bijvoorbeeld iets mee wil doen. Op het moment dat je bijvoorbeeld op een rustige plek bevindt, zal hij dus niet inbeslaggenomen worden. 

In risicogebieden geldt het gedoogbeleid niet en zijn steek- en slagwapens altijd verboden. Hier zul je dus ook altijd aangehouden worden voor bezit van een steek- of slagwapen.