### PR TITLE
Aanpassing A5 - Strafblad

### DIFF
--- a/docs/wetboek.md
+++ b/docs/wetboek.md
@@ -54,7 +54,7 @@
 
 1. Straffen die enige vorm van celstraf bevatten kunnen leiden tot een strafblad.
 2. Een strafblad blijft staan voor een periode van 2 (realtime) maanden voor alle geweldsdelicten met celstraf, en 1 maand voor alle overige delicten met celstraf, ingaand op de datum van de opgelegde straf.
-3. Wanneer een nieuwe overtreding of een misdrijf wordt begaan, wordt de resterende tijd gereset naar de datum van de laatst opgelegde celstraf.
+3. Wanneer een nieuwe overtreding of een misdrijf wordt begaan, wordt de resterende tijd gereset naar de datum van de laatst opgelegde celstraf. Dit geldt enkel als het nieuwe strafblad langer blijft staan dan het huidige strafblad.
 
 ### A6 - Verduidelijking en algemene aanvulling
 


### PR DESCRIPTION
Artikel A5 - Strafblad is aangepast zodat het vanaf heden niet meer mogelijk is om onterecht eerder een VOG te claimen omdat je een nieuw strafblad hebt gekregen die minder lang duurt dan het oude strafblad.