### PR TITLE
Aanpassing Artikel III-14 Illegale voertuigen

### DIFF
--- a/docs/wetboek.md
+++ b/docs/wetboek.md
@@ -607,12 +607,6 @@ Onder terroristisch misdrijf/daad wordt verstaan het oogmerk om de bevolking of 
 | Manchez | Motor |
 | Sanchez | Motor |
 | Sanchez Sport | Motor |
-| 911 GT3-R | Circuit auto |
-| Chevrolet C7-R | Circuit auto |
-| Lamborghini Huracan GT3 | Circuit auto |
-| Audi R8 LMS | Circuit auto |
-| Ferrari 488 GT3 | Circuit auto |
-| McLaren MP4-12C GT3 | Circuit auto |
 
 ## Titel IV - Opiumwet
 


### PR DESCRIPTION
Artikel III-14 Illegale voertuigen is aangepast, zodanig dat circuitauto's geen illegale voertuigen meer zijn. Ze kunnen nog wel inbeslaggenomen worden, maar zullen niet direct vernietigd worden.