### PR TITLE
feature(main.yml): Skip Discord commits als WEBHOOK undefined is

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,7 @@ jobs:
 #           embed: '{ "title": "{{ commit.title }}", "description": "{{ commit.description }}", "url": "{{ commit.url }}", "author": { "name": "{{ commit.author.name }} ({{ commit.author.username }})", "icon_url": "https://avatars.io/gravatar/{{ commit.author.email }}"} }'
       - name: Discord Commits
         uses: Tedeapolis/discord-commits@v1.2.5
+        if: "${{ env.INPUT_WEBHOOK != '' }}"
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           message: "Successful commit to **{{ github.context.payload.repository.name}}**.\nDiff: {{ github.context.payload.compare }}"


### PR DESCRIPTION
Kleine qol fix voor forks om the checken of alles compiled.

Kan dit niet testen of de Discord Commits zo nog werkt dus dat zou je even moeten checken bij het deployen.

Oh en blijkbaar zijn hier m'n changes voor belastingen, dacht dat ik die op de master branch van Tedeapolis had gemaakt, maar I guess niet, weet niet zeker wat daar gebeurt is.