### PR TITLE
Artikel N-4.1 aanpassing

### DIFF
--- a/docs/apv.md
+++ b/docs/apv.md
@@ -575,7 +575,7 @@ Onderstaande regels tellen alleen op Narcopolis
 
 ### Artikel N-4 - Samenwerking criminele organisaties
 
-1. Op Narcopolis is het voor een officiële en onofficiele groep niet toegestaan om samen te werken met een officiele of onofficiele groep of persoon.
+1. Op Narcopolis is het voor een officiële groep niet toegestaan om samen te werken met een officiele of onofficiele groep of persoon.
 2. Uitzondering op lid 1 is er voor het kopen en verkopen van drugs. Dit mag wel gedaan worden op het eiland tussen verschillende groepen en personen.
 3. Bij overtreding van lid 1 zal dit resulteren in een straf volgens de 5e categorie voor iedereen die meedeed aan het Roleplayscenario.
 4. Bij herhaling na de straf van de 5e categorie wordt er een gang strike uitgedeeld.


### PR DESCRIPTION
Dit omdat een onofficiële groep niet iets wat wij na kunnen zoeken via de officiële weg (MEOS), tevens hebben onofficiële geen jobhop en kunnen deze het ene uur bij groep A horen en het andere uur bij groep B. Dit is toegestaan zolang ze niet over de limiet van 20 man heengaan.

Aanpassing moet besproken worden in staffoverleg.