### PR TITLE
Toevoeging van strafbaarstelling gekleurde koplampen

### DIFF
--- a/docs/kosten/politie.md
+++ b/docs/kosten/politie.md
@@ -69,6 +69,7 @@ De politie hanteert de volgende boetebedragen. Deze kunnen ten alle tijden worde
 | Opzettelijk veroorzaken van ernstig gevaar of hinder - eerste veroordeling | € 3000,- |
 | Opzettelijk veroorzaken van ernstig gevaar of hinder - tweede veroordeling | € 7500,- |
 | Opzettelijk veroorzaken van ernstig gevaar of hinder - derde veroordeling | € 10500,- |
+| Rijden met koplampen met een andere lichtkleur dan wit | € 5000,- |
 
 ## Klein misdrijf
 

--- a/docs/kosten/politie.md
+++ b/docs/kosten/politie.md
@@ -69,7 +69,7 @@ De politie hanteert de volgende boetebedragen. Deze kunnen ten alle tijden worde
 | Opzettelijk veroorzaken van ernstig gevaar of hinder - eerste veroordeling | € 3000,- |
 | Opzettelijk veroorzaken van ernstig gevaar of hinder - tweede veroordeling | € 7500,- |
 | Opzettelijk veroorzaken van ernstig gevaar of hinder - derde veroordeling | € 10500,- |
-| Rijden met koplampen met een andere lichtkleur dan wit | € 5000,- |
+| Rijden met koplampen met een andere lichtkleur dan wit of geel | € 5000,- |
 
 ## Klein misdrijf
 

--- a/docs/wetboek.md
+++ b/docs/wetboek.md
@@ -555,7 +555,7 @@ Onder terroristisch misdrijf/daad wordt verstaan het oogmerk om de bevolking of 
 5. Bij het voertuig mogen geen deuren ontbreken, indien deze wel aanwezig behoren te zijn.
 6. Het voertuig dient een eentonige claxon te voeren.
 7. Het voertuig dient vrij te zijn van een WOK-status bij deelname aan het verkeer.
-8. Het licht van de koplampen van het voertuigen dient een witte kleur te hebben.
+8. Het licht van de koplampen van het voertuigen dient een witte of gele kleur te hebben.
 
 #### Strafbepalingen Voertuigeisen
 
@@ -577,7 +577,7 @@ Onder terroristisch misdrijf/daad wordt verstaan het oogmerk om de bevolking of 
 | Rijden zonder kentekenplaten | € 10000,- |
 | Ramen dusdanig donker getint zodat de bestuurder en passagier voor in niet zichtbaar zijn | € 7500,- |
 | Verlichting(NEON) onder het voertuig | € 2500,- |
-| Rijden met koplampen met een andere lichtkleur dan wit | € 5000,- |
+| Rijden met koplampen met een andere lichtkleur dan wit of geel | € 5000,- |
 
 ### Artikel III-13 Overige verkeersboetes
 

--- a/docs/wetboek.md
+++ b/docs/wetboek.md
@@ -553,6 +553,7 @@ Onder terroristisch misdrijf/daad wordt verstaan het oogmerk om de bevolking of 
 5. Bij het voertuig mogen geen deuren ontbreken, indien deze wel aanwezig behoren te zijn.
 6. Het voertuig dient een eentonige claxon te voeren.
 7. Het voertuig dient vrij te zijn van een WOK-status bij deelname aan het verkeer.
+8. Het licht van de koplampen van het voertuigen dient een witte kleur te hebben.
 
 #### Strafbepalingen Voertuigeisen
 
@@ -574,6 +575,7 @@ Onder terroristisch misdrijf/daad wordt verstaan het oogmerk om de bevolking of 
 | Rijden zonder kentekenplaten | € 10000,- |
 | Ramen dusdanig donker getint zodat de bestuurder en passagier voor in niet zichtbaar zijn | € 7500,- |
 | Verlichting(NEON) onder het voertuig | € 2500,- |
+| Rijden met koplampen met een andere lichtkleur dan wit | € 5000,- |
 
 ### Artikel III-13 Overige verkeersboetes
 


### PR DESCRIPTION
Het is verboden om te rijden met een voertuig met daarop koplampen die licht afgeven in een andere kleur dan wit. Mocht deze regel overtreden worden, dan wordt er een boete en een WOK-status uitgedeeld.