### PR TITLE
Aanpassing van A8 - Openstaande boetes

### DIFF
--- a/docs/wetboek.md
+++ b/docs/wetboek.md
@@ -98,7 +98,7 @@
 1. Wanneer tijdens een controle of aanhouding aangetoond wordt dat het totaalbedrag van openstaande boetes boven de € 10000,- reikt, kan dit impact hebben op de strafeis.
     1. Wanneer dit aangetoond wordt bij het opvragen van een inbeslaggenomen goed of voertuig kan geëist worden eerst het boetebedrag te voldoen;
     2. Wanneer dit aangetoond wordt tijdens onderzoek volgende op een misdrijf of crimineel feit kan hiervoor een boete of taakstraf worden opgelegd;
-    3. De hoogte van deze boete of taakstraf is ter beoordeling van de Officier van Dienst.
+    3. De hoogte van deze boete of taakstraf is ter beoordeling van de hulpOfficier van Justitie.
     4. Deze boete of taakstraf wordt bijgevoegd bij de totale straf eis.
 2. Onder het voldoen van het boetebedrag wordt verstaan tenminste een zodanige betaling te voldoen dat het totale boetebedrag onder de € 10000,- komt.
 


### PR DESCRIPTION
In plaats van de officier van dienst, staat er nu dat er een hOvJ beslist over de hoogte van een eventuele sanctie na een teveel aan openstaande boetes.