### PR TITLE
Stemherkenning terugbrengen in de APV

### DIFF
--- a/docs/apv.md
+++ b/docs/apv.md
@@ -283,6 +283,13 @@ een melding maken en de ambulancier snel te laten werken zodat het wapen direct 
 
    *Bij overtreding zal gestraft worden volgens de 1e categorie en zal de desbetreffende persoon worden ontslagen en deze persoon mag dit beroep 3 kalenderdagen lang niet uitvoeren.
 
+### Artikel 19 - Stemherkenning
+
+1. Het is toegestaan om een speler te herkennen aan zijn/haar stem, tenzij je hem/haar totaal niet kent. Indien hierom gevraagd word, dien je dit aan te kunnen tonen.
+2. Indien de speler duidelijk moeite doet om zijn stem te vervormen, dan is het niet toegestaan om een speler aan zijn/haar stem te herkennen.
+3. Het is toegestaan om gebruik te maken van externe software om je stem te vervormen gedurende het uitvoeren van criminele activiteiten, echter dient dit normaal te blijven.
+4. Het overtreden van de feiten beschreven in lid 1,2 & 3 zullen worden gestraft met een straf van de eerste categorie.
+
 ## Narcopolis
 
 Onderstaande regels tellen alleen op Narcopolis


### PR DESCRIPTION
Deze is verdwenen uit de APV, waardoor dit een vage regel is geworden. Nieuwe spelers kunnen niet weten dat deze regel bestaat en zo maak je het duidelijk voor iedereen.

Heb de regel van vroeger als voorbeeld genomen, aangezien hier alles duidelijk in staat. Heb de regels omtrent enkel een stem verlagen, weggelaten aangezien stafleden hier zelf kunnen bepalen of het toegestaan is of niet. Sommige spelers kunnen met een lichtere stem spelen, aangezien hun stem van nature zwaar is.