### PR TITLE
Dashcam foto fix + typo fix

### DIFF
--- a/docs/apv.md
+++ b/docs/apv.md
@@ -397,7 +397,7 @@ Onderstaande regels tellen alleen op Narcopolis
 
 ### Bijlage 1
 
-![bijlage-1](https://tedeapolis.nl/wp-content/uploads/2021/08/Schermafbeelding_2021-08-23_om_10.png)
+![Bijlage-1](img/apv/dashcamUitleg.webp)
 
 ### Bijlage 2
 

--- a/docs/douanegebieden.md
+++ b/docs/douanegebieden.md
@@ -6,4 +6,4 @@ De korpsleiding is bevoegd om, in samenspraak met de gemeenteraad van Tedeapolis
 
 ## Kaartweergave
 
-![Kaart met duanegebieden](img/douaneGebieden.webp)
+![Kaart met douanegebieden](img/douaneGebieden.webp) 

--- a/docs/douanegebieden.md
+++ b/docs/douanegebieden.md
@@ -6,4 +6,4 @@ De korpsleiding is bevoegd om, in samenspraak met de gemeenteraad van Tedeapolis
 
 ## Kaartweergave
 
-![Kaart met douanegebieden](img/douaneGebieden.webp) 
+![Kaart met douanegebieden](img/douaneGebieden.webp)

--- a/docs/img/apv/dashcamUitleg.webp
+++ b/docs/img/apv/dashcamUitleg.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66716a4cc514f5685630b43de146930e60a1d3688080a0c011650d8b23216742
+size 12558


### PR DESCRIPTION
De huidige dashcam foto ging via de TDA website, echter moet je daar eerst verifiëren dat je een mens bent waardoor de foto niet werkt. Dit is de fix + douanegebieden typo.